### PR TITLE
Add tagging for detected trampoline functions

### DIFF
--- a/src/main/java/lol/fairplay/ghidraapple/analysis/selectortrampoline/SelectorTrampolineAnalyzer.kt
+++ b/src/main/java/lol/fairplay/ghidraapple/analysis/selectortrampoline/SelectorTrampolineAnalyzer.kt
@@ -130,11 +130,7 @@ class SelectorTrampolineAnalyzer : AbstractAnalyzer(NAME, DESCRIPTION, AnalyzerT
         // Find (and store) functions that match the trampoline instruction signature for the current CPU.
         findTrampolines(monitor, addresses, program)
 
-        // Step 1: rename trampolines.
         renameTrampolines(monitor)
-
-        // Step 2: analyze class implementors.
-        //  analyzeTrampolineClassImplementors(monitor)
 
         if (shouldMoveSelRefs) {
             copyXRefData(monitor)


### PR DESCRIPTION
A constant for the tag name and description has been added to the SelectorTrampolineAnalyzer. The analyzer will now generate and attach these tags to any detected Objective-C selector trampoline functions. This binds metadata that will be used by analyzers and features in the future.